### PR TITLE
Add RacketUp section and info pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,19 +32,27 @@
                     <a href="http://www.onlinebasketballassociation.com" target="_blank" rel="noopener noreferrer">Visit OBA Website</a>
                 </div>
             </div>
+            <div class="service-highlight">
+                <img src="assets/racketup_logo.png" alt="RacketUp Logo">
+                <div class="description">
+                    <h3>RacketUp</h3>
+                    <p>RacketUp brings the same depth and excitement of OBA to racket sports. Manage leagues for pickleball, tennis, and ping pong with tools designed to help you organize teams and compete in realistic seasons. Built from the OBA framework, RacketUp delivers an engaging community-driven experience for all racket sport enthusiasts.</p>
+                    <a href="racketup.html">More about RacketUp</a>
+                </div>
+            </div>
         </section>
 
         <section id="contact">
             <h2>Contact Us</h2>
             <p>If you have any inquiries or would like to get in touch with SixEx Tech LLC, please reach out to us via email.</p>
-            <p>Email: <a href="mailto:sixextech@gmail.com">sixextech@gmail.com</a></p>
+            <p>Email: <a href="mailto:business@sixextech.com">business@sixextech.com</a></p>
         </section>
     </main>
 
     <footer>
         <div class="container">
             <p>&copy; 2025 SixEx Tech LLC. All rights reserved.</p>
-            <p>Contact: <a href="mailto:sixextech@gmail.com">sixextech@gmail.com</a></p>
+            <p>Contact: <a href="mailto:business@sixextech.com">business@sixextech.com</a></p>
         </div>
     </footer>
 </body>

--- a/racketup.html
+++ b/racketup.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RacketUp - More Info</title>
+    <link rel="stylesheet" href="index.css">
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>RacketUp</h1>
+        </div>
+    </header>
+
+    <main class="container">
+        <section>
+            <h2>About RacketUp</h2>
+            <p>RacketUp is built on the same proven platform as the Online Basketball Association but tailored for racket sports including pickleball, tennis and ping pong.</p>
+            <ul>
+                <li><a href="racketup_privacy.html">Privacy Policy</a></li>
+                <li><a href="racketup_terms.html">Terms of Service</a></li>
+            </ul>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 SixEx Tech LLC. All rights reserved.</p>
+            <p>Contact: <a href="mailto:business@sixextech.com">business@sixextech.com</a></p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/racketup_privacy.html
+++ b/racketup_privacy.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RacketUp Privacy Policy</title>
+    <link rel="stylesheet" href="index.css">
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>RacketUp Privacy Policy</h1>
+        </div>
+    </header>
+
+    <main class="container">
+        <section>
+            <p>This page outlines how RacketUp collects and uses your data. The app follows the same practices as the Online Basketball Association platform. We value your privacy and handle all information responsibly.</p>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 SixEx Tech LLC. All rights reserved.</p>
+            <p>Contact: <a href="mailto:business@sixextech.com">business@sixextech.com</a></p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/racketup_terms.html
+++ b/racketup_terms.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RacketUp Terms of Service</title>
+    <link rel="stylesheet" href="index.css">
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>RacketUp Terms of Service</h1>
+        </div>
+    </header>
+
+    <main class="container">
+        <section>
+            <p>These Terms of Service govern the use of the RacketUp application. By accessing or using RacketUp you agree to the same rules and guidelines that apply to the Online Basketball Association platform.</p>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 SixEx Tech LLC. All rights reserved.</p>
+            <p>Contact: <a href="mailto:business@sixextech.com">business@sixextech.com</a></p>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a RacketUp section that mirrors the OBA section
- create dedicated RacketUp info page with links to privacy policy and terms of service
- provide stub privacy policy and terms of service pages
- update email references to business@sixextech.com

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b9a4bfe64832caf9d41178360e478