### PR TITLE
Update RacketUp info

### DIFF
--- a/index.css
+++ b/index.css
@@ -98,6 +98,11 @@ p {
   border-radius: 4px;
 }
 
+.store-badge {
+  max-height: 40px;
+  margin-left: 5px;
+}
+
 .service-highlight .description {
   flex: 1;
   min-width: 250px;

--- a/index.html
+++ b/index.html
@@ -25,18 +25,20 @@
             <h2>Our Services</h2>
             <p>We are proud to present our first major project, the Online Basketball Association (OBA). This platform offers a unique digital experience for basketball enthusiasts.</p>
             <div class="service-highlight">
-                <img src="assets/obalogo.png" alt="Online Basketball Association Logo">
+                <img src="obalogo.png" alt="Online Basketball Association Logo">
                 <div class="description">
                     <h3>Online Basketball Association (OBA)</h3>
                     <p>Experience the thrill of managing your own basketball association online. OBA provides a comprehensive platform for users to engage with virtual basketball leagues, manage teams, and compete with others. Built with a focus on community and realistic simulation, OBA aims to be the premier destination for online basketball management fans.</p>
                     <a href="http://www.onlinebasketballassociation.com" target="_blank" rel="noopener noreferrer">Visit OBA Website</a>
+                    <a href="https://apps.apple.com/us/app/online-basketball-association/id6747052163" target="_blank" rel="noopener noreferrer"><img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="Download on the App Store" class="store-badge"></a>
+                    <a href="https://play.google.com/store/apps/details?id=com.onlinebasketballassociation.android" target="_blank" rel="noopener noreferrer"><img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" class="store-badge"></a>
                 </div>
             </div>
             <div class="service-highlight">
-                <img src="assets/racketup_logo.png" alt="RacketUp Logo">
+                <img src="racketuplogo.png" alt="RacketUp Logo">
                 <div class="description">
                     <h3>RacketUp</h3>
-                    <p>RacketUp brings the same depth and excitement of OBA to racket sports. Manage leagues for pickleball, tennis, and ping pong with tools designed to help you organize teams and compete in realistic seasons. Built from the OBA framework, RacketUp delivers an engaging community-driven experience for all racket sport enthusiasts.</p>
+                    <p>RacketUp is a standalone platform for racket sports that lets players report scores, join leagues, and compete in full seasons. As a sister app to our basketball platform, it delivers the same robust features for pickleball, tennis, and ping pong communities.</p>
                     <a href="racketup.html">More about RacketUp</a>
                 </div>
             </div>

--- a/racketup.html
+++ b/racketup.html
@@ -16,7 +16,7 @@
     <main class="container">
         <section>
             <h2>About RacketUp</h2>
-            <p>RacketUp is built on the same proven platform as the Online Basketball Association but tailored for racket sports including pickleball, tennis and ping pong.</p>
+            <p>RacketUp is a standalone mobile app dedicated to racket sports such as pickleball, tennis and ping pong. It allows players to report scores, join leagues and compete in full seasons with the same comprehensive features offered by our basketball platform.</p>
             <ul>
                 <li><a href="racketup_privacy.html">Privacy Policy</a></li>
                 <li><a href="racketup_terms.html">Terms of Service</a></li>

--- a/racketup_privacy.html
+++ b/racketup_privacy.html
@@ -15,7 +15,229 @@
 
     <main class="container">
         <section>
-            <p>This page outlines how RacketUp collects and uses your data. The app follows the same practices as the Online Basketball Association platform. We value your privacy and handle all information responsibly.</p>
+<h1 id="racketup-privacy-policy">RacketUp Privacy Policy</h1>
+<p><strong>Last Updated: 6/19/2025</strong></p>
+<h2 id="introduction">1. Introduction</h2>
+<p>The RacketUp (“RacketUp”, “we”, “our”, or “us”) is committed to
+protecting your privacy. This Privacy Policy explains how we collect,
+use, disclose, and safeguard your information when you use our website,
+mobile application, and any related services (the “Service”). By using
+the Service, you consent to the practices described in this Privacy
+Policy.</p>
+<h2 id="information-we-collect">2. Information We Collect</h2>
+<h3 id="personal-information-provided-by-you">2.1. Personal Information
+Provided by You</h3>
+<p>When you register for an account or use certain features of our
+Service, you may provide us with the following information:</p>
+<ul>
+<li><strong>Contact Information:</strong> Full name and email
+address.</li>
+<li><strong>Account Credentials:</strong> Username and password (which
+we securely hash using bcrypt).</li>
+<li><strong>Profile Information:</strong> Height, weight, bio, and
+profile picture.</li>
+<li><strong>Verification Documents:</strong> A government-issued photo
+ID is required for account verification (required for ranked matches).
+Note that although you upload a photo for verification purposes, the
+image is used solely for automated verification with our AI service (via
+AWS Textract) and is deleted immediately after processing.</li>
+<li><strong>Preferences:</strong> Various settings that control how your
+information is displayed and how you interact with other users (e.g.,
+messaging preferences).</li>
+<li><strong>Additional Data:</strong> Information related to match
+history, scores, and messaging content, which may include on service
+text messages, friend requests, reports, notifications, and match
+details.</li>
+<li><strong>League Information:</strong> When creating or joining
+leagues, we collect league names, membership information, league
+settings, and league profile pictures.</li>
+<li><strong>QR Code Data:</strong> When using QR code functionality to
+join matches, we process the encoded match information.</li>
+</ul>
+<h3 id="automatically-collected-information">2.2. Automatically
+Collected Information</h3>
+<p>When you use our Service, we may automatically collect certain
+information about your usage:</p>
+<ul>
+<li><strong>Usage Data:</strong> Information about your interactions
+with the Service (e.g., pages accessed, match history, game statistics,
+league participation).</li>
+<li><strong>Log Data:</strong> Details such as IP addresses, browser
+type, operating system, and access times.</li>
+<li><strong>Authentication Data:</strong> JSON Web Tokens (JWTs) that
+facilitate secure sessions and verify your identity.</li>
+</ul>
+<h2 id="how-we-use-your-information">3. How We Use Your Information</h2>
+<p>We use the collected information for various purposes, including:</p>
+<ul>
+<li><strong>Account Management:</strong> To create, maintain, and secure
+your account; to verify your identity during registration and for ranked
+matches; and to enable password resets.</li>
+<li><strong>Service Delivery:</strong> To facilitate online matchmaking,
+record match outcomes, update player statistics, and support
+game-related communications.</li>
+<li><strong>League Management:</strong> To create and manage leagues,
+process league invitations, handle league membership, and facilitate
+league-specific match history.</li>
+<li><strong>QR Code Functionality:</strong> To process QR codes for
+match joining and verification purposes.</li>
+<li><strong>Communication:</strong> To send verification emails,
+password reset links, and notifications regarding friend requests, match
+updates, disputes, league invites, or other account-related
+matters.</li>
+<li><strong>Customer Support:</strong> To respond to your inquiries and
+resolve technical or security issues.</li>
+<li><strong>Improvement of Services:</strong> To analyze usage trends
+and improve the functionality and performance of our Service.</li>
+<li><strong>Compliance and Security:</strong> To detect, prevent, and
+address security breaches, fraud, or any unauthorized use of our
+Service.</li>
+</ul>
+<h2 id="disclosure-of-your-information">4. Disclosure of Your
+Information</h2>
+<h3 id="third-party-service-providers">4.1. Third-Party Service
+Providers</h3>
+<p>We may share your information with third parties that help us operate
+our Service, including:</p>
+<ul>
+<li><strong>Cloud and Database Services:</strong> Our data is stored in
+a MongoDB database.</li>
+<li><strong>Email Service Providers:</strong> We use Flask-Mail (and
+related SMTP services) to send emails.</li>
+<li><strong>ID Verification Services:</strong> AWS Textract is used for
+verifying uploaded identification documents. Please note that while we
+process your ID photo using AWS Textract, the image is not stored after
+verification.</li>
+<li><strong>Image Storage Services:</strong> AWS S3 is used for storing
+profile pictures, league pictures, and other media content.</li>
+<li><strong>Other Third Parties:</strong> Any additional integrations or
+services may have access only to the information required to perform
+their functions and are bound by confidentiality agreements.</li>
+</ul>
+<h3 id="legal-disclosures">4.2. Legal Disclosures</h3>
+<p>We may disclose your information if required to do so by law or in
+the good-faith belief that such action is necessary to:</p>
+<ul>
+<li>Comply with a legal obligation.</li>
+<li>Protect and defend our rights or property.</li>
+<li>Prevent or investigate possible wrongdoing in connection with the
+Service.</li>
+<li>Protect the personal safety of users of the Service or the
+public.</li>
+</ul>
+<h2 id="data-storage-and-security">5. Data Storage and Security</h2>
+<h3 id="data-storage">5.1. Data Storage</h3>
+<ul>
+<li><strong>Personal Data:</strong> Your account information, match
+history, messages, league membership data, and related information are
+stored in our MongoDB database.</li>
+<li><strong>Uploaded Media:</strong> Profile pictures, league pictures,
+and article images are stored on our server (in designated upload
+folders) or in AWS S3 storage. All media files are subject to the access
+and retention policies described below.</li>
+<li><strong>Temporary Data:</strong> ID verification photos are
+processed using AWS Textract and are deleted immediately after
+verification; they are not stored on our backend.</li>
+<li><strong>QR Code Data:</strong> QR code data is processed in
+real-time and is not stored separately from the match information it
+represents.</li>
+</ul>
+<h3 id="security-measures">5.2. Security Measures</h3>
+<p>We take reasonable precautions to protect your information from loss,
+misuse, unauthorized access, disclosure, alteration, or destruction.
+These measures include:</p>
+<ul>
+<li><strong>Encryption:</strong> Passwords are hashed using encryption,
+and sensitive data transmissions are protected by HTTPS.</li>
+<li><strong>Access Controls:</strong> Access to personal data is limited
+to authorized personnel who require such access to operate, develop, or
+improve our Service.</li>
+<li><strong>Regular Audits:</strong> We perform regular security reviews
+and updates to ensure the integrity and security of our systems.</li>
+<li><strong>Data Minimization:</strong> We retain only the data
+necessary for the purposes outlined in this Privacy Policy.</li>
+</ul>
+<h3 id="retention">5.3. Retention</h3>
+<p>We retain your personal information for as long as necessary to
+fulfill the purposes for which it was collected and to comply with
+applicable legal requirements. When no longer needed, we securely delete
+or anonymize your data.</p>
+<h2 id="your-rights-and-choices">6. Your Rights and Choices</h2>
+<h3 id="account-access-and-updates">6.1. Account Access and Updates</h3>
+<ul>
+<li><strong>Viewing and Editing:</strong> You may access, update, or
+correct your personal information by logging into your account and
+adjusting your settings.</li>
+<li><strong>Deletion:</strong> You may request the deletion of your
+account and associated data by contacting us at the email address
+provided below. Please note that certain information may need to be
+retained for legal or security purposes.</li>
+<li><strong>Account Deletion Process:</strong> When you delete your
+account, we use a “soft delete” approach that anonymizes your personal
+information while preserving the integrity of match history and league
+data. Specifically:
+<ol type="1">
+<li>Your personal information (name, email, bio, height, weight) is
+either anonymized or removed.</li>
+<li>Your username is changed to “Deleted Account” and your profile
+picture is removed.</li>
+<li>Your account is marked as deleted with a timestamp.</li>
+<li>Your friends list is emptied, but your account remains visible as
+“Deleted Account” in other users’ friends lists.</li>
+<li>All pending friend requests involving your account are removed.</li>
+<li>Your notifications are deleted.</li>
+<li>Your match history and statistics remain in the system to maintain
+game integrity and other users’ records.</li>
+<li>Your league memberships remain, but your username shows as “Deleted
+Account” in league rosters and match history.</li>
+</ol>
+This approach ensures that deleting your account doesn’t break the
+application’s functionality for other users while still respecting your
+privacy by removing your personal information.</li>
+</ul>
+<h3 id="communication-preferences">6.2. Communication Preferences</h3>
+<ul>
+<li><strong>Opting Out:</strong> You can opt out of receiving marketing
+communications by following the unsubscribe instructions in our emails.
+Please note that you may still receive transactional or service-related
+messages.</li>
+</ul>
+<h3 id="data-portability-and-access-requests">6.3. Data Portability and
+Access Requests</h3>
+<p>Subject to applicable law, you may request access to, correction of,
+or deletion of your personal data. To exercise these rights, please
+contact us at the address provided below.</p>
+<h2 id="childrens-privacy">7. Children’s Privacy</h2>
+<p>Our Service is not directed to individuals under the age of 16. We do
+not knowingly collect personal information from children under 16. If we
+become aware that we have collected personal information from a child
+under 16, we will take steps to delete the information as soon as
+possible.</p>
+<h2 id="international-data-transfers">8. International Data
+Transfers</h2>
+<p>If you are accessing our Service from outside the United States,
+please be aware that your information may be transferred to and stored
+on servers located in the United States or other countries where our
+service providers operate. By using our Service, you consent to the
+transfer of your information to these jurisdictions.</p>
+<h2 id="third-party-links-and-integrations">9. Third-Party Links and
+Integrations</h2>
+<p>Our Service may contain links to third-party websites or services
+that are not operated by us. We are not responsible for the privacy
+practices of these third parties. We encourage you to review the privacy
+policies of any third-party sites you visit.</p>
+<h2 id="changes-to-this-privacy-policy">10. Changes to This Privacy
+Policy</h2>
+<p>We may update this Privacy Policy from time to time. When we make
+material changes, we will provide notice by updating the “Last Updated”
+date at the top of this policy and, in some cases, by notifying you
+directly via email or through the Service. Your continued use of the
+Service after such changes will constitute your acceptance of the
+updated policy.</p>
+<h2 id="contact-us">11. Contact Us</h2>
+<p>If you have any questions, concerns, or requests regarding this
+Privacy Policy or our data practices, please contact us at:</p>
+<p><strong>Email:</strong> connectwithoba@gmail.com</p>
         </section>
     </main>
 

--- a/racketup_terms.html
+++ b/racketup_terms.html
@@ -15,7 +15,361 @@
 
     <main class="container">
         <section>
-            <p>These Terms of Service govern the use of the RacketUp application. By accessing or using RacketUp you agree to the same rules and guidelines that apply to the Online Basketball Association platform.</p>
+<h1 id="racketup-terms-of-service">RacketUp Terms of Service</h1>
+<p><em>Last Updated: 6/19/2025</em></p>
+<h2 id="introduction">1. Introduction</h2>
+<p>Welcome to the RacketUp (“RacketUp”, “we”, “our”, or “us”). These
+Terms of Service (“Terms”) govern your use of our website, mobile
+application, and any other services we provide (collectively, the
+“Service”). By accessing or using our Service, you agree to be bound by
+these Terms. If you do not agree to these Terms, please do not access or
+use our Service.</p>
+<p>The RacketUp is a service designed to facilitate online matchmaking
+and competition for racket-sport players. We are the owner of the domain
+and have a pending trademark registration for the RacketUp name.</p>
+<h2 id="acceptance-of-terms">2. Acceptance of Terms</h2>
+<p>By accessing, browsing, or using the Service in any manner, you
+acknowledge that you have read, understood, and agree to be bound by
+these Terms. Your continued use of the Service will be deemed acceptance
+of any modifications to these Terms, which we may post from time to
+time.</p>
+<h2 id="eligibility">3. Eligibility</h2>
+<p>To use the Service, you must meet the following eligibility
+criteria:</p>
+<ul>
+<li><strong>Age Requirement</strong>: You must be at least 16 years of
+age. If you are under the age of 18, you must have your parent or legal
+guardian’s permission to use the Service.</li>
+<li><strong>Verification</strong>: In order to participate in ranked
+matches, you must provide a government-issued photo ID for verification
+purposes. This verification is solely for ensuring fair play and is
+conducted using AI services, after which the images are immediately
+deleted.</li>
+<li><strong>Residency</strong>: The Service is available to users
+worldwide; however, you are solely responsible for complying with any
+local laws that may apply.</li>
+</ul>
+<h2 id="account-registration-and-security">4. Account Registration and
+Security</h2>
+<h3 id="registration">4.1. Registration</h3>
+<ul>
+<li><strong>Information</strong>: To register an account, you must
+provide accurate and complete information, including your full name,
+email address, phone number, and other required details.</li>
+<li><strong>Verification</strong>: After initial registration, you may
+be required to verify your identity via government-issued
+identification. Failure to provide accurate identification may limit
+your ability to participate in certain features (e.g., ranked matches,
+climbing leaderboards).</li>
+</ul>
+<h3 id="account-security">4.2. Account Security</h3>
+<ul>
+<li>You are responsible for safeguarding your account credentials and
+for all activities that occur under your account.</li>
+<li>You agree to notify us immediately of any unauthorized use of your
+account or any other breach of security.</li>
+</ul>
+<h2 id="user-responsibilities">5. User Responsibilities</h2>
+<p>As a user of the Service, you agree to:</p>
+<ul>
+<li><strong>Provide Accurate Information</strong>: Ensure that all
+information you provide is truthful, accurate, and complete.</li>
+<li><strong>Compliance with Laws</strong>: Use the Service in compliance
+with all applicable local, state, national, and international laws and
+regulations.</li>
+<li><strong>Maintain Security</strong>: Keep your account credentials
+confidential and secure.</li>
+<li><strong>Report Issues</strong>: Promptly notify us of any security
+vulnerabilities or breaches you discover.</li>
+</ul>
+<h2 id="prohibited-conduct">6. Prohibited Conduct</h2>
+<p>You agree not to engage in any conduct that may harm the Service, its
+users, or its reputation. This includes, but is not limited to:</p>
+<ul>
+<li><strong>Harassment and Hate Speech</strong>: No harassment, hate
+speech, or discriminatory language directed at other users.</li>
+<li><strong>Fraudulent Activity</strong>: Engaging in win fraud (e.g.,
+artificially boosting win counts, using fake accounts, or instructing
+other users to intentionally lose to manipulate rankings).</li>
+<li><strong>Match Dispute Abuse</strong>: Abusing the match dispute
+system by falsely reporting scores or engaging in behaviors intended to
+disrupt the integrity of the match.</li>
+<li><strong>League Manipulation</strong>: Creating fake leagues,
+manipulating league standings, or abusing league administrative
+privileges.</li>
+<li><strong>QR Code Misuse</strong>: Creating counterfeit QR codes,
+scanning QR codes without authorization, or using QR codes to bypass
+security measures.</li>
+<li><strong>Inappropriate Content</strong>: Posting, soliciting, or
+sharing content that is pornographic, offensive, or otherwise
+inappropriate.</li>
+<li><strong>Violence</strong>: Inciting or engaging in physical
+altercations or any behavior that could lead to physical harm.</li>
+<li><strong>Unauthorized Access</strong>: Attempting to gain
+unauthorized access to any part of the Service, or interfering with or
+disrupting the Service or its servers.</li>
+<li><strong>Circumvention of Verification</strong>: Using any means to
+bypass or tamper with the identity verification process.</li>
+</ul>
+<p>Any violation of these provisions may result in immediate suspension
+or termination of your account and access to the Service.</p>
+<h2 id="payment-terms-and-future-services">7. Payment Terms and Future
+Services</h2>
+<p>At present, the RacketUp does not offer in-app payments or
+subscriptions. However, should such services be introduced in the
+future:</p>
+<ul>
+<li><strong>Billing Practices</strong>: Any fees or subscription charges
+will be clearly disclosed before payment is processed.</li>
+<li><strong>Refund Policy</strong>: Refunds, if applicable, will be
+handled in accordance with our refund policy, which will be provided at
+the time of purchase.</li>
+<li><strong>Modifications</strong>: We reserve the right to modify
+payment terms and pricing at any time. Notice of such changes will be
+provided in advance.</li>
+</ul>
+<h2 id="intellectual-property">8. Intellectual Property</h2>
+<ul>
+<li><strong>Ownership</strong>: All content, trademarks, and specific
+service markers used on the Service, including the “RacketUp” name, are
+the exclusive property of RacketUp or our licensors. Unauthorized use of
+any materials is prohibited.</li>
+<li><strong>License</strong>: We grant you a limited, revocable,
+non-transferable license to use the Service solely for your personal,
+non-commercial use.</li>
+</ul>
+<h2 id="user-generated-content">9. User-Generated Content</h2>
+<ul>
+<li><strong>Ownership</strong>: You retain ownership of any content you
+submit, post, or display on or through the Service.</li>
+<li><strong>Grant of Rights</strong>: By submitting content, you grant
+RacketUp a non-exclusive, royalty-free, worldwide license to use,
+display, reproduce, modify, and distribute your content solely as
+necessary to operate and promote the Service.</li>
+<li><strong>Responsibility</strong>: You represent and warrant that you
+have all necessary rights to submit the content and that your content
+does not infringe on any third-party rights.</li>
+<li><strong>Content Moderation</strong>: RacketUp reserves the right to
+remove or modify any content that violates these Terms or is otherwise
+objectionable, without prior notice.</li>
+</ul>
+<h3 id="content-filtering-and-user-safety">9.1 Content Filtering and
+User Safety</h3>
+<p>We maintain a strict, zero-tolerance approach toward objectionable
+content:</p>
+<ul>
+<li><strong>Automated and Manual Monitoring</strong>: Public areas of
+the Service are scanned by automated filters and watched by our
+moderation team 24/7. Content that appears objectionable is flagged for
+immediate review.</li>
+<li><strong>Reporting and 24-Hour Response</strong>: You may report
+abusive users or content through the in-app reporting tools. Our team is
+alerted instantly and will remove the offending material and eject the
+offending user within 24 hours of the report.</li>
+<li><strong>Blocking Abusive Users</strong>: You can block other users
+at any time. Blocked users cannot contact you and will no longer appear
+anywhere in your Service experience.</li>
+</ul>
+<h2 id="league-functionality">10. League Functionality</h2>
+<h3 id="league-creation-and-management">10.1. League Creation and
+Management</h3>
+<ul>
+<li><strong>League Creation</strong>: Users may create leagues to
+organize and track matches between members.</li>
+<li><strong>League Administration</strong>: League creators have
+administrative privileges to manage league settings, membership, and
+content.</li>
+<li><strong>League Content</strong>: League creators and members may
+contribute content to leagues, including league pictures, match results,
+and communications.</li>
+</ul>
+<h3 id="league-membership">10.2. League Membership</h3>
+<ul>
+<li><strong>Invitations</strong>: Users may send and receive league
+invitations.</li>
+<li><strong>Joining Leagues</strong>: Users may join leagues through
+invitations or by using league codes.</li>
+<li><strong>Leaving Leagues</strong>: Users may leave leagues at any
+time, but their match history within the league will be retained.</li>
+</ul>
+<h3 id="league-conduct">10.3. League Conduct</h3>
+<ul>
+<li>League creators and administrators are responsible for ensuring that
+league activities comply with these Terms.</li>
+<li>RacketUp reserves the right to remove or suspend leagues that
+violate these Terms or engage in prohibited conduct.</li>
+</ul>
+<h2 id="qr-code-functionality">11. QR Code Functionality</h2>
+<h3 id="qr-code-generation-and-scanning">11.1. QR Code Generation and
+Scanning</h3>
+<ul>
+<li><strong>Match Joining</strong>: QR codes may be generated and
+scanned to facilitate joining matches.</li>
+<li><strong>Security</strong>: QR codes contain encoded information
+related to matches and are processed in real-time.</li>
+</ul>
+<h3 id="qr-code-usage">11.2. QR Code Usage</h3>
+<ul>
+<li>You agree to use QR codes only for their intended purpose within the
+Service.</li>
+<li>You agree not to create, distribute, or use counterfeit QR codes or
+use QR codes to bypass security measures.</li>
+</ul>
+<h2 id="privacy-and-data-security">12. Privacy and Data Security</h2>
+<ul>
+<li><strong>Data Collection</strong>: To use the Service, you are
+required to provide personal information (e.g., name, phone number,
+email, and government-issued photo ID for verification).</li>
+<li><strong>Data Handling</strong>: All collected personal information
+will be used solely for account verification, security, and Service
+functionality. In particular, any ID photos provided for verification
+are processed immediately by our AI verification service and are not
+ever stored on our backend.</li>
+<li><strong>Privacy Policy</strong>: Please refer to our Privacy Policy
+for detailed information on how we collect, use, and protect your
+data.</li>
+<li><strong>User Responsibility</strong>: You are responsible for
+maintaining the confidentiality of your account and login
+information.</li>
+</ul>
+<h2 id="disclaimer-of-warranties">13. Disclaimer of Warranties</h2>
+<ul>
+<li><strong>“As Is” Basis</strong>: The Service is provided on an “as
+is” and “as available” basis without any warranties of any kind, either
+express or implied.</li>
+<li><strong>No Warranty of Accuracy</strong>: We do not guarantee that
+the Service will be error-free, secure, or continuously available.</li>
+<li><strong>User-Generated Content</strong>: RacketUp is not responsible
+for the accuracy, reliability, or legality of any content submitted by
+users.</li>
+<li><strong>Third-Party Services</strong>: Our Service may include links
+or integrations with third-party services, for which we do not assume
+any liability or responsibility.</li>
+</ul>
+<h2 id="limitation-of-liability">14. Limitation of Liability</h2>
+<p>To the fullest extent permitted by applicable law, RacketUp and its
+affiliates, officers, directors, employees, agents, or licensors shall
+not be liable for any indirect, incidental, special, consequential, or
+punitive damages arising out of or relating to your use of the Service,
+including but not limited to:</p>
+<ul>
+<li><strong>Physical or Mental Harm</strong>: Any injuries, damages, or
+losses arising from user interactions or in-person meet-ups arranged
+through the Service.</li>
+<li><strong>Loss of Data or Revenue</strong>: Any loss of data, revenue,
+or goodwill.</li>
+<li><strong>Unauthorized Access</strong>: Any damages resulting from
+unauthorized access to user accounts.</li>
+<li><strong>Disputes</strong>: Any disputes or disagreements between
+users.</li>
+</ul>
+<p>This limitation applies regardless of whether such liability is based
+on contract, tort, negligence, strict liability, or any other legal
+theory, even if RacketUp has been advised of the possibility of such
+damages.</p>
+<h2 id="indemnification">15. Indemnification</h2>
+<p>You agree to indemnify, defend, and hold harmless RacketUp, its
+affiliates, officers, directors, employees, agents, and licensors from
+and against any claims, actions, demands, liabilities, costs, or
+expenses (including reasonable attorneys’ fees) arising out of or
+relating to:</p>
+<ul>
+<li>Your use of the Service;</li>
+<li>Your violation of these Terms;</li>
+<li>Your infringement or violation of any rights of a third party;</li>
+<li>Any other conduct that may be deemed objectionable.</li>
+</ul>
+<h2 id="third-party-services">16. Third-Party Services</h2>
+<ul>
+<li><strong>Integration</strong>: The Service may integrate with or use
+third-party services (e.g., payment processors, notification systems, or
+identity verification services).</li>
+<li><strong>No Endorsement</strong>: RacketUp does not endorse and is
+not responsible for the actions or content of any third-party
+service.</li>
+<li><strong>Your Responsibility</strong>: Any interactions or
+transactions with third parties are solely between you and the third
+party, and you agree that RacketUp is not liable for any losses or
+damages arising from such interactions.</li>
+</ul>
+<h2 id="termination">17. Termination</h2>
+<p>We reserve the right to suspend or terminate your account and access
+to the Service at our sole discretion, without prior notice, for any of
+the following reasons:</p>
+<ul>
+<li><strong>Violation of Terms</strong>: If you violate these Terms or
+engage in any prohibited conduct.</li>
+<li><strong>Fraudulent Activity</strong>: If you engage in win fraud,
+match dispute abuse, or any other form of fraudulent behavior.</li>
+<li><strong>Harmful Behavior</strong>: If your actions are deemed
+harmful to other users or to the integrity of the Service.</li>
+<li><strong>Fraudulent Verification</strong>: If in any way you
+circumvent the verification process artificially, you are subject to
+termination.</li>
+</ul>
+<p>Upon termination, your right to use the Service will immediately
+cease. All provisions of these Terms that by their nature should survive
+termination shall remain in effect.</p>
+<h2 id="dispute-resolution">18. Dispute Resolution</h2>
+<h3 id="informal-resolution">18.1. Informal Resolution</h3>
+<p>In the event of any dispute, controversy, or claim arising out of or
+relating to these Terms or the Service, we encourage you to first
+contact us at business@sixextech.com so that we may attempt to resolve
+the matter amicably.</p>
+<h3 id="binding-arbitration">18.2. Binding Arbitration</h3>
+<p>If the dispute is not resolved informally, you agree that any and all
+claims arising out of or related to these Terms, your use of the
+Service, or any disputes between you and RacketUp shall be finally and
+exclusively resolved through binding arbitration. The arbitration shall
+be conducted in accordance with the rules of a recognized arbitration
+institution agreed upon by both parties.</p>
+<ul>
+<li><strong>Class Action Waiver</strong>: You agree that any arbitration
+shall be conducted on an individual basis and not as a class action or
+representative proceeding.</li>
+</ul>
+<h3 id="jurisdiction">18.3. Jurisdiction</h3>
+<p>These Terms shall be governed by and construed in accordance with the
+laws of the United States, without regard to its conflict of law
+provisions. Any disputes arising under or in connection with these Terms
+shall be subject to the exclusive jurisdiction of the federal and state
+courts located in the United States.</p>
+<h2 id="governing-law">19. Governing Law</h2>
+<p>These Terms shall be governed by and construed in accordance with the
+laws of the United States. By using the Service, you consent to the
+exclusive jurisdiction and venue of the U.S. federal and state courts in
+any dispute arising out of or relating to these Terms.</p>
+<h2 id="changes-to-these-terms">20. Changes to These Terms</h2>
+<p>We reserve the right to modify or update these Terms at any time. Any
+changes will be effective immediately upon posting the revised Terms on
+our website or within the app. Your continued use of the Service after
+the posting of any changes constitutes your acceptance of such changes.
+It is your responsibility to review these Terms periodically for any
+updates.</p>
+<h2 id="contact-information">21. Contact Information</h2>
+<p>If you have any questions, concerns, or comments regarding these
+Terms, please contact us at:</p>
+<p>Email: business@sixextech.com</p>
+<h2 id="miscellaneous">22. Miscellaneous</h2>
+<h3 id="severability">22.1. Severability</h3>
+<p>If any provision of these Terms is held to be invalid or
+unenforceable, such provision shall be struck and the remaining
+provisions shall be enforced to the fullest extent under law.</p>
+<h3 id="entire-agreement">22.2. Entire Agreement</h3>
+<p>These Terms, along with our Privacy Policy and any other legal
+notices published on the Service, constitute the entire agreement
+between you and RacketUp regarding your use of the Service, superseding
+any prior agreements.</p>
+<h3 id="no-waiver">22.3. No Waiver</h3>
+<p>Failure by RacketUp to enforce any provision of these Terms shall not
+be deemed a waiver of that provision or any other provision.</p>
+<h3 id="assignment">22.4. Assignment</h3>
+<p>These Terms are personal to you and may not be assigned or
+transferred without our prior written consent. We may assign or transfer
+these Terms or any rights or obligations hereunder without your
+consent.</p>
+<p>By using the RacketUp Service, you acknowledge that you have read,
+understood, and agree to be bound by these Terms of Service.</p>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- update service highlight with store badges and new logo paths
- tweak RacketUp app description text
- embed Privacy Policy and Terms of Service content in respective pages
- set style for store badges

## Testing
- `pandoc -v`

------
https://chatgpt.com/codex/tasks/task_e_687b9f80c860832c97e7849af3f67955