### PR TITLE
Remove blue outline on store badges

### DIFF
--- a/index.css
+++ b/index.css
@@ -99,7 +99,7 @@ p {
 }
 
 .store-badge {
-  max-height: 90px;
+  max-height: 120px;
   margin-left: 5px;
   border: none;
   display: inline-block;
@@ -108,6 +108,12 @@ p {
 a img.store-badge {
   border: none;
 }
+.store-link {
+  display: inline-block;
+  border: none;
+  background: none;
+}
+
 
 .service-highlight .description {
   flex: 1;

--- a/index.html
+++ b/index.html
@@ -30,8 +30,8 @@
                     <h3>Online Basketball Association (OBA)</h3>
                     <p>Experience the thrill of managing your own basketball association online. OBA provides a comprehensive platform for users to engage with virtual basketball leagues, manage teams, and compete with others. Built with a focus on community and realistic simulation, OBA aims to be the premier destination for online basketball management fans.</p>
                     <a class="button-link" href="http://www.onlinebasketballassociation.com" target="_blank" rel="noopener noreferrer">Visit OBA Website</a>
-                    <a href="https://apps.apple.com/us/app/online-basketball-association/id6747052163" target="_blank" rel="noopener noreferrer"><img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="Download on the App Store" class="store-badge"></a>
-                    <a href="https://play.google.com/store/apps/details?id=com.onlinebasketballassociation.android" target="_blank" rel="noopener noreferrer"><img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" class="store-badge"></a>
+                    <a class="store-link" href="https://apps.apple.com/us/app/online-basketball-association/id6747052163" target="_blank" rel="noopener noreferrer"><img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="Download on the App Store" class="store-badge"></a>
+                    <a class="store-link" href="https://play.google.com/store/apps/details?id=com.onlinebasketballassociation.android" target="_blank" rel="noopener noreferrer"><img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" class="store-badge"></a>
                 </div>
             </div>
             <div class="service-highlight">


### PR DESCRIPTION
## Summary
- enlarge download badges
- remove border on app store and play store links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bac9da6f0832ca71e65dfddb9261d